### PR TITLE
Update starting GSoC information on site

### DIFF
--- a/content/pages/programs/gsoc.rst
+++ b/content/pages/programs/gsoc.rst
@@ -7,7 +7,6 @@ NumFOCUS is an umbrella organization for Google Summer of Code. To learn more ab
 
 * `Mailing list <https://groups.google.com/a/numfocus.org/forum/#!forum/gsoc>`_
 * `GSOC repo <https://github.com/numfocus/gsoc>`_
-* `Ideas Wiki <https://github.com/numfocus/gsoc/wiki/GSOC-2015>`_
-
+* `Ideas list <https://github.com/numfocus/gsoc/blob/master/ideas-list.md>`_
 
 Org Administrators: Raniere Silva <raniere@ime.unicamp.br> and Andy Terrel <andy.terrel@gmail.com>

--- a/content/pages/programs/gsoc.rst
+++ b/content/pages/programs/gsoc.rst
@@ -7,6 +7,5 @@ NumFOCUS is an umbrella organization for Google Summer of Code. To learn more ab
 
 * `Mailing list <https://groups.google.com/a/numfocus.org/forum/#!forum/gsoc>`_
 * `GSOC repo <https://github.com/numfocus/gsoc>`_
-* `Ideas list <https://github.com/numfocus/gsoc/blob/master/ideas-list.md>`_
 
 Org Administrators: Raniere Silva <raniere@ime.unicamp.br> and Andy Terrel <andy.terrel@gmail.com>

--- a/content/pages/programs/index.rst
+++ b/content/pages/programs/index.rst
@@ -6,3 +6,4 @@ Programs
 * `Conferences <|filename|conferences.rst>`_
 * `Fellowships <|filename|fellowships.rst>`_
 * `Women in Technology <|filename|women-in-technology.rst>`_
+* `Google Summer of Code <|filename|gsoc.rst>`_


### PR DESCRIPTION
This change adds a link for the GSoC project to the Projects landing page, and it changes the link from the wiki to [ideas-list.md](https://github.com/numfocus/gsoc/blob/master/ideas-list.md) since that seems to be the place where ideas information lives?